### PR TITLE
Nitz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,102 @@
-*.swp
-*.pyc
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/jsondate/__init__.py
+++ b/jsondate/__init__.py
@@ -1,5 +1,7 @@
+from __future__ import absolute_import
 import datetime
 import json
+import six
 
 DATE_FMT = '%Y-%m-%d'
 ISO8601_FMT = '%Y-%m-%dT%H:%M:%SZ'
@@ -15,7 +17,7 @@ def _datetime_encoder(obj):
 
 
 def _datetime_decoder(dict_):
-    for key, value in dict_.iteritems():
+    for key, value in six.iteritems(dict_):
         # The built-in `json` library will `unicode` strings, except for empty
         # strings which are of type `str`. `jsondate` patches this for
         # consistency so that `unicode` is always returned.

--- a/jsondate3/__init__.py
+++ b/jsondate3/__init__.py
@@ -23,7 +23,7 @@ def _datetime_decoder(dict_):
         # strings which are of type `str`. `jsondate` patches this for
         # consistency so that `unicode` is always returned.
         if value == '':
-            dict_[key] = ''
+            dict_[key] = six.text_type()
             continue
 
         try:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,9 @@ setuptools.setup(
     zip_safe=False,
     include_package_data=True,
     platforms='any',
-    install_requires=[''],
+    install_requires=[
+        'six',
+    ],
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',

--- a/tests/test_jsondate.py
+++ b/tests/test_jsondate.py
@@ -1,10 +1,12 @@
+from __future__ import absolute_import
 import datetime
 import json
 import unittest
-import StringIO
 
 import jsondate
+import six
 
+StringIO = six.moves.cStringIO
 
 class JSONDateTests(unittest.TestCase):
     def assertTypeAndValue(self, expected_type, expected_value, result):
@@ -21,16 +23,15 @@ class JSONDateTests(unittest.TestCase):
 
     def test_dump_unicode_roundtrips(self):
         orig_dict = {u'foo': u'bar', 'empty': u''}
-
         # json module broken: unicode objects, empty-string objects are str
         result = json.loads(json.dumps(orig_dict))
-        self.assertTypeAndValue(unicode, u'bar', result[u'foo'])
-        self.assertTypeAndValue(str, '', result[u'empty'])
+        self.assertTypeAndValue(six.text_type, u'bar', result[u'foo'])
+        self.assertTypeAndValue(six.text_type, '', result[u'empty'])
 
         # jsondate fix: always return unicode objects
         result = jsondate.loads(jsondate.dumps(orig_dict))
-        self.assertTypeAndValue(unicode, u'bar', result[u'foo'])
-        self.assertTypeAndValue(unicode, u'', result[u'empty'])
+        self.assertTypeAndValue(six.text_type, u'bar', result[u'foo'])
+        self.assertTypeAndValue(six.text_type, u'', result[u'empty'])
 
     def test_dumps_none_roundtrips(self):
         # Generates a TypeError from _datetime_object_hook
@@ -57,7 +58,7 @@ class JSONDateTests(unittest.TestCase):
 
     def test_dump_datetime_roundtrips(self):
         orig_dict = dict(created_at=datetime.date(2011, 1, 1))
-        fileobj = StringIO.StringIO()
+        fileobj = StringIO()
         jsondate.dump(orig_dict, fileobj)
         fileobj.seek(0)
         self.assertEqual(orig_dict, jsondate.load(fileobj))


### PR DESCRIPTION
I have been helping with the freelaw project.  The project depends on jsondate, and both py2/py3 support is needed.  There are two issues, #7, and #8 that request this.  It seems that the original project is dead.  The freelaw project leader would like to fork the project, but we noticed that you already have "jsondate3" listed on pypi.

We were wondering, since you are more active and have a package available on pypi, if you were willing to accept six as a dependency, so that the package can remain compatible with py2 and  upload a new version with this change into pypi.